### PR TITLE
feat: Add receipt/invoice file attachments (#11)

### DIFF
--- a/app/components/attachment_list_component.html.erb
+++ b/app/components/attachment_list_component.html.erb
@@ -1,0 +1,27 @@
+<% if attachments.attached? %>
+  <div class="mt-4">
+    <h3 class="text-sm font-medium text-gray-700 mb-2">Attached Receipts</h3>
+    <ul class="space-y-2">
+      <% attachments.each do |attachment| %>
+        <li class="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-200">
+          <div class="flex items-center space-x-3">
+            <% if attachment.image? %>
+              <svg class="w-6 h-6 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+              </svg>
+            <% else %>
+              <svg class="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+              </svg>
+            <% end %>
+            <div>
+              <p class="text-sm font-medium text-gray-900"><%= attachment.filename %></p>
+              <p class="text-xs text-gray-500"><%= number_to_human_size(attachment.byte_size) %></p>
+            </div>
+          </div>
+          <%= link_to "Download", rails_blob_path(attachment, disposition: "attachment"), class: "text-sm text-blue-600 hover:text-blue-800" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/components/attachment_list_component.rb
+++ b/app/components/attachment_list_component.rb
@@ -1,0 +1,9 @@
+class AttachmentListComponent < ViewComponent::Base
+  def initialize(attachments:)
+    @attachments = attachments
+  end
+
+  def attachments
+    @attachments
+  end
+end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -69,6 +69,6 @@ class ExpensesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def expense_params
-      params.expect(expense: [ :amount, :description, :expense_date, :expense_type, :category, :vendor, :notes ])
+      params.expect(expense: [ :amount, :description, :expense_date, :expense_type, :category, :vendor, :notes, receipts: [] ])
     end
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -1,5 +1,6 @@
 class Expense < ApplicationRecord
   belongs_to :user
+  has_many_attached :receipts
 
   enum :expense_type, { personal: 0, business: 1 }
 

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -45,6 +45,19 @@
       <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-2" %>
       <%= form.text_area :notes, rows: 2, placeholder: "Additional notes (optional)", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
     </div>
+
+    <div class="md:col-span-2">
+      <%= form.label :receipts, "Receipt/Invoice Files", class: "block text-sm font-medium text-gray-700 mb-2" %>
+      <div class="mt-2">
+        <%= form.file_field :receipts, multiple: true, accept: "image/*,application/pdf", class: "block w-full text-sm text-gray-500
+          file:mr-4 file:py-2 file:px-4
+          file:rounded-md file:border-0
+          file:text-sm file:font-semibold
+          file:bg-blue-50 file:text-blue-700
+          hover:file:bg-blue-100" %>
+        <p class="mt-1 text-xs text-gray-500">Upload receipt or invoice files (PDF, JPG, PNG)</p>
+      </div>
+    </div>
   </div>
 
   <div class="mt-6 flex justify-end">

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -44,6 +44,11 @@
           <p class="text-gray-600"><%= @expense.notes %></p>
         </div>
       <% end %>
+
+      <!-- Receipt Attachments -->
+      <div class="md:col-span-2">
+        <%= render AttachmentListComponent.new(attachments: @expense.receipts) %>
+      </div>
     </div>
 
     <!-- Action Buttons -->

--- a/db/migrate/20251018122330_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20251018122330_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_30_062057) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_18_122330) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "expenses", force: :cascade do |t|
     t.decimal "amount"
     t.text "description"
@@ -37,5 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_30_062057) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "expenses", "users"
 end

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -47,4 +47,42 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to expenses_url
   end
+
+  test "should create expense with receipt attachments" do
+    file1 = fixture_file_upload("receipt1.pdf", "application/pdf")
+    file2 = fixture_file_upload("receipt2.jpg", "image/jpeg")
+
+    assert_difference("Expense.count") do
+      post expenses_url, params: {
+        expense: {
+          amount: 100.50,
+          description: "Test expense",
+          expense_date: Date.today,
+          expense_type: "business",
+          category: "Office",
+          vendor: "Test Vendor",
+          receipts: [ file1, file2 ]
+        }
+      }
+    end
+
+    expense = Expense.last
+    assert_equal 2, expense.receipts.count
+    assert_redirected_to expense_url(expense)
+  end
+
+  test "should update expense and add receipt attachments" do
+    file = fixture_file_upload("receipt1.pdf", "application/pdf")
+
+    patch expense_url(@expense), params: {
+      expense: {
+        amount: @expense.amount,
+        receipts: [ file ]
+      }
+    }
+
+    @expense.reload
+    assert_equal 1, @expense.receipts.count
+    assert_redirected_to expense_url(@expense)
+  end
 end

--- a/test/fixtures/files/receipt1.pdf
+++ b/test/fixtures/files/receipt1.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000052 00000 n
+0000000101 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+178
+%%EOF

--- a/test/fixtures/files/receipt2.jpg
+++ b/test/fixtures/files/receipt2.jpg
@@ -1,0 +1,1 @@
+fake jpg content for testing

--- a/test/models/expense_test.rb
+++ b/test/models/expense_test.rb
@@ -1,7 +1,32 @@
 require "test_helper"
 
 class ExpenseTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "can attach receipt files" do
+    expense = expenses(:one)
+
+    assert_respond_to expense, :receipts
+  end
+
+  test "can attach multiple receipt files" do
+    expense = expenses(:one)
+
+    file1 = fixture_file_upload("receipt1.pdf", "application/pdf")
+    file2 = fixture_file_upload("receipt2.jpg", "image/jpeg")
+
+    expense.receipts.attach(file1)
+    expense.receipts.attach(file2)
+
+    assert_equal 2, expense.receipts.count
+  end
+
+  test "can check if expense has attached receipts" do
+    expense = expenses(:one)
+
+    assert_not expense.receipts.attached?
+
+    file = fixture_file_upload("receipt1.pdf", "application/pdf")
+    expense.receipts.attach(file)
+
+    assert expense.receipts.attached?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ module ActiveSupport
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+    include ActionDispatch::TestProcess::FixtureFile
   end
 end
 


### PR DESCRIPTION
## Summary
Implements **Issue #11** - Receipt/Invoice file attachments for expenses

This PR adds the ability for users to upload and attach receipt/invoice files to their expenses, a critical feature for tax compliance for Japanese freelancers.

## Changes

### Model Layer
- ✅ Add `has_many_attached :receipts` to Expense model
- ✅ Install and configure Active Storage
- ✅ Support multiple file attachments per expense

### Controller Layer
- ✅ Permit `receipts` parameter in `expense_params`
- ✅ Handle file uploads in create/update actions

### View Layer
- ✅ Add file upload field to expense form (PDF, JPG, PNG)
- ✅ Create `AttachmentListComponent` for displaying attachments
- ✅ Show attached files on expense detail page with download links
- ✅ Responsive UI with Tailwind CSS styling

### Tests (TDD)
- ✅ Model tests for attachment functionality (3 tests)
- ✅ Controller tests for file upload/update (2 tests)
- ✅ All 17 tests passing
- ✅ RuboCop clean (0 offenses)

## Acceptance Criteria

- [x] Users can upload files when creating/editing expenses
- [x] Multiple file formats supported (PDF, JPG, PNG)
- [x] Files are stored securely via Active Storage
- [x] Attached files display in expense detail view
- [x] Users can download attached files
- [x] Tests cover file upload functionality

## Screenshots
N/A - Feature complete and tested

## Test Plan
1. Run full test suite: `bin/rails test` ✅
2. Check linting: `bin/rubocop` ✅
3. Manual testing:
   - Create expense with file attachments
   - Update expense to add more files
   - View attachments on detail page
   - Download attached files

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)