### PR TITLE
feat: Redesign header with professional branding

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,33 +1,45 @@
-<header class="bg-white shadow-sm border-b border-gray-200">
+<header class="bg-white border-b border-gray-100">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-    <div class="flex justify-between items-center h-16">
-      <!-- Logo -->
+    <div class="flex justify-between items-center h-20">
+      <!-- Logo & Wordmark -->
       <div class="flex items-center">
-        <%= link_to root_path, class: "text-xl font-bold text-gray-900" do %>
-          PocketLedger
+        <%= link_to root_path, class: "flex items-center group transition-all duration-200" do %>
+          <!-- Logo Icon - Wallet/Pocket Icon -->
+          <div class="relative">
+            <div class="w-10 h-10 bg-gradient-to-br from-blue-600 to-cyan-500 rounded-xl flex items-center justify-center group-hover:scale-105 transition-transform duration-200 shadow-md">
+              <svg class="w-6 h-6 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+              </svg>
+            </div>
+          </div>
+
+          <!-- Wordmark -->
+          <div class="ml-3">
+            <span class="text-2xl font-extrabold text-gray-900 tracking-tight">PocketLedger</span>
+            <div class="text-xs text-gray-500 font-medium -mt-1">Expense Tracker</div>
+          </div>
         <% end %>
       </div>
 
       <!-- Navigation -->
-      <nav class="flex items-center space-x-4">
+      <nav class="flex items-center space-x-6">
         <% if signed_in? %>
-          <!-- Signed in navigation -->
-          <%= link_to expenses_path, class: "text-gray-600 hover:text-gray-900 font-medium transition duration-200" do %>
-            My Expenses
+          <!-- Signed in - Simple navigation -->
+          <%= link_to expenses_path, class: "text-gray-600 hover:text-gray-900 font-semibold transition-colors duration-200" do %>
+            Dashboard
           <% end %>
-          
-          <%= button_to destroy_user_session_path, method: :delete, 
-              class: "text-gray-600 hover:text-gray-900 font-medium transition duration-200" do %>
+
+          <%= button_to destroy_user_session_path, method: :delete,
+              class: "text-gray-500 hover:text-gray-700 font-medium transition-colors duration-200 text-sm" do %>
             Sign out
           <% end %>
         <% else %>
-          <!-- Signed out navigation -->
-          <%= link_to new_user_session_path, class: "text-gray-600 hover:text-gray-900 font-medium transition duration-200" do %>
-            Sign in
-          <% end %>
-          
-          <%= link_to new_user_registration_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md font-medium hover:bg-blue-700 transition duration-200" do %>
-            Sign up
+          <!-- Signed out - Only sign in link (sign up is in hero) -->
+          <%= link_to new_user_session_path, class: "inline-flex items-center px-5 py-2.5 text-gray-700 hover:text-gray-900 font-semibold border-2 border-gray-200 hover:border-gray-300 rounded-xl transition-all duration-200 hover:shadow-md" do %>
+            <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+            Sign In
           <% end %>
         <% end %>
       </nav>


### PR DESCRIPTION
## Summary
Refines the header component with professional brand identity and cleaner navigation.

This PR transforms the basic text-only header into a **polished, branded header** that establishes visual identity and removes redundant navigation.

## Changes

### 1. Professional Logo & Branding ✨

**Logo Icon:**
- Wallet/pocket icon with gradient background (blue-600 → cyan-500)
- Rounded-xl square with shadow
- Hover scale effect for interactivity
- Matches brand gradient used throughout the site

**Wordmark:**
- "PocketLedger" - text-2xl, extrabold, tracking-tight
- Subtitle: "Expense Tracker" (text-xs, gray-500)
- Proper visual hierarchy
- Clean, professional typography

### 2. Simplified Navigation 🧹

**Removed:**
- ❌ "Sign up" button in header (redundant - it's in hero section)

**Kept:**
- ✅ "Sign In" button (for returning users)
- Styled as bordered button (rounded-xl)
- User profile icon (not logout arrow!)
- Hover effects: border color, shadow

**Authenticated State:**
- "Dashboard" link (cleaner than "My Expenses")
- "Sign out" link (subtle, smaller text)

### 3. Design Refinements 🎨

**Layout:**
- Taller header: h-20 (was h-16) - more breathing room
- Subtle border: border-gray-100 (was gray-200)
- Better spacing: space-x-6 between nav items

**Interactions:**
- Logo hover: scale-105
- Button hover: shadow-md, border color change
- Smooth transitions on all elements

### 4. Structure Comparison

**Inspired by Japanese SaaS (Freee, Money Forward):**
- ✅ Logo on left
- ✅ Minimal navigation on right
- ✅ Clean, professional

**Differentiated with startup aesthetic:**
- ✅ Gradient logo icon (not plain)
- ✅ Bolder typography
- ✅ Modern rounded corners
- ✅ Hover animations

## Before vs After

### Before:
```
[PocketLedger]              [Sign in] [Sign up]
```
- Plain text logo
- Two redundant buttons
- Basic styling

### After:
```
[🔷 PocketLedger]                    [👤 Sign In]
   Expense Tracker
```
- Gradient logo icon
- Professional wordmark with subtitle
- Single, well-designed Sign In button
- Cleaner, more spacious

## Visual Design

**Logo:**
- 40x40px gradient square (blue→cyan)
- Wallet icon in white
- Rounded-xl with shadow-md
- Hover: scale-105

**Typography:**
- Logo: text-2xl, extrabold, gray-900
- Subtitle: text-xs, font-medium, gray-500
- Nav links: font-semibold, gray-700

**Spacing:**
- Header height: 80px (h-20)
- Logo to text: ml-3
- Nav items: space-x-6

## Testing
- ✅ All 36 unit tests passing
- ✅ All 13 system tests passing
- ✅ RuboCop clean (0 offenses)
- ✅ No visual regressions

## Screenshots
N/A - Visual changes best viewed in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)