### PR TITLE
feat: Add consecutive multiple expense entry feature (#31)

### DIFF
--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -96,8 +96,19 @@
     </div>
   </div>
 
-  <div class="mt-6 flex justify-end">
-    <%= form.submit class: "px-6 py-2 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition duration-200" %>
+  <div class="mt-6 flex justify-between items-center">
+    <%if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>
+      <div class="text-sm text-green-600 font-medium">
+        ✅ <%= pluralize(flash[:consecutive_count], 'expense') %> created this session
+      </div>
+    <% else %>
+      <div></div>
+    <% end %>
+
+    <div class="flex gap-3">
+      <%= form.submit "Save Expense", class: "px-6 py-2 bg-gray-100 text-gray-700 font-medium rounded-xl hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition duration-200" %>
+      <%= form.submit "Create & Add Another", name: "add_another", class: "px-6 py-2 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition duration-200 shadow-md hover:shadow-lg" %>
+    </div>
   </div>
 <% end %>
 

--- a/test/system/consecutive_expense_entry_test.rb
+++ b/test/system/consecutive_expense_entry_test.rb
@@ -1,0 +1,80 @@
+require "application_system_test_case"
+
+class ConsecutiveExpenseEntryTest < ApplicationSystemTestCase
+  setup do
+    sign_in users(:one)
+  end
+
+  test "creating expense with 'Create Another' pre-fills common fields" do
+    visit new_expense_path
+
+    # Fill in first expense
+    fill_in "Amount", with: 1500
+    fill_in "Expense date", with: "2025-01-15"
+    select "Business", from: "Expense type"
+    fill_in "Category", with: "Food"
+    fill_in "Vendor", with: "Starbucks"
+    fill_in "Description", with: "Coffee meeting"
+
+    # Click "Create & Add Another"
+    click_button "Create & Add Another"
+
+    # Should stay on new expense form
+    assert_current_path new_expense_path
+
+    # Common fields should be pre-filled
+    # Check that expense type and category are pre-filled
+    assert_select "Expense type", selected: "Business"
+    assert_field "Category", with: "Food"
+
+    # Check that date field has a value (pre-filled, even if format varies)
+    date_field = find_field("Expense date")
+    assert date_field.value.present?, "Date field should be pre-filled"
+
+    # Unique fields should be cleared
+    assert_field "Amount", with: ""
+    assert_field "Vendor", with: ""
+    assert_field "Description", with: ""
+
+    # Should show success message
+    assert_text "Expense created! Add another or view all expenses."
+  end
+
+  test "creating expense with 'Done' redirects to index" do
+    visit new_expense_path
+
+    fill_in "Amount", with: 1500
+    fill_in "Expense date", with: "2025-01-15"
+    select "Business", from: "Expense type"
+
+    # Click regular submit button (Done)
+    click_button "Save Expense"
+
+    # Should redirect to show page (current behavior)
+    assert_text "Expense was successfully created"
+  end
+
+  test "session counter shows number of expenses created" do
+    visit new_expense_path
+
+    # Create first expense
+    fill_in "Amount", with: 1000
+    fill_in "Expense date", with: "2025-01-15"
+    select "Personal", from: "Expense type"
+    click_button "Create & Add Another"
+
+    assert_text "1 expense created this session"
+
+    # Create second expense
+    fill_in "Amount", with: 2000
+    click_button "Create & Add Another"
+
+    assert_text "2 expenses created this session"
+
+    # Create third expense
+    fill_in "Amount", with: 3000
+    click_button "Create & Add Another"
+
+    assert_text "3 expenses created this session"
+  end
+end

--- a/test/system/expenses_test.rb
+++ b/test/system/expenses_test.rb
@@ -19,7 +19,7 @@ class ExpensesTest < ApplicationSystemTestCase
     fill_in "Amount", with: 1000
     select "Business", from: "Expense type"
     fill_in "Category", with: "Office"
-    find('input[type="submit"]').click
+    click_button "Save Expense"
 
     assert_text "Expense was successfully created"
   end


### PR DESCRIPTION
## Summary
Implements **Issue #31** - Consecutive expense entry workflow

This PR adds a "killer feature" that enables users to log multiple expenses consecutively without re-entering common fields. Perfect for batch entry scenarios like logging a day's worth of expenses or entering multiple receipts at once.

## Changes

### Controller Layer (app/controllers/expenses_controller.rb)

#### 1. Enhanced `new` Action - Pre-fill from Query Params
```ruby
def new
  # Pre-fill from params if coming from "Create Another" flow
  expense_date = if params[:expense_date].present?
                   begin
                     Date.parse(params[:expense_date])
                   rescue ArgumentError
                     Date.current
                   end
                 else
                   Date.current
                 end

  @expense = current_user.expenses.build(
    expense_date: expense_date,
    expense_type: params[:expense_type] || :personal,
    category: params[:category]
  )
end
```
- Date parsing with error handling (prevents crashes)
- Pre-fills expense_type, expense_date, category from query params
- Defaults to current date and :personal type

#### 2. Enhanced `create` Action - Two Submission Modes
```ruby
if @expense.save
  # Increment consecutive entry counter
  session[:consecutive_count] ||= 0
  session[:consecutive_count] += 1

  # Check if user clicked "Create & Add Another"
  if params[:add_another].present?
    flash[:notice] = "Expense created! Add another or view all expenses."
    flash[:consecutive_count] = session[:consecutive_count]
    
    # Redirect to new form with pre-filled params
    redirect_to new_expense_path(
      expense_date: @expense.expense_date.to_s,
      expense_type: @expense.expense_type,
      category: @expense.category
    )
  else
    # Normal flow - reset counter and redirect to show
    session[:consecutive_count] = 0
    redirect_to @expense, notice: "Expense was successfully created."
  end
end
```
- Session-based counter for consecutive entries
- Two paths: consecutive entry vs normal submit
- Pre-fills common fields for next entry

### View Layer (app/views/expenses/_form.html.erb)

#### 1. Two Submit Buttons
```erb
<div class="flex gap-3">
  <%= form.submit "Save Expense", 
      class: "px-6 py-2 bg-gray-100 text-gray-700 font-medium rounded-xl hover:bg-gray-200..." %>
  <%= form.submit "Create & Add Another", 
      name: "add_another", 
      class: "px-6 py-2 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700..." %>
</div>
```
- **"Save Expense"** (gray) - Normal flow, redirects to detail page
- **"Create & Add Another"** (blue, highlighted) - Consecutive entry flow
- Clear visual hierarchy - blue button is primary action during batch entry

#### 2. Session Counter Display
```erb
<% if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>
  <div class="text-sm text-green-600 font-medium">
    ✅ <%= pluralize(flash[:consecutive_count], 'expense') %> created this session
  </div>
<% end %>
```
- Shows progress during consecutive entry
- Uses Rails `pluralize` helper for correct grammar
- Green color for positive feedback

### System Tests (TDD - RED-GREEN-REFACTOR)

**Test File:** `test/system/consecutive_expense_entry_test.rb`

#### Test 1: Pre-fill Common Fields
```ruby
test "creating expense with 'Create Another' pre-fills common fields" do
  visit new_expense_path
  fill_in "Amount", with: 1500
  fill_in "Expense date", with: "2025-01-15"
  select "Business", from: "Expense type"
  fill_in "Category", with: "Food"
  fill_in "Vendor", with: "Starbucks"
  fill_in "Description", with: "Coffee meeting"
  
  click_button "Create & Add Another"
  
  # Should stay on new expense form
  assert_current_path new_expense_path
  
  # Common fields should be pre-filled
  assert_select "Expense type", selected: "Business"
  assert_field "Category", with: "Food"
  date_field = find_field("Expense date")
  assert date_field.value.present?, "Date field should be pre-filled"
  
  # Unique fields should be cleared
  assert_field "Amount", with: ""
  assert_field "Vendor", with: ""
  assert_field "Description", with: ""
  
  assert_text "Expense created! Add another or view all expenses."
end
```

#### Test 2: Normal Submit Flow
```ruby
test "creating expense with 'Done' redirects to index" do
  visit new_expense_path
  fill_in "Amount", with: 1500
  select "Business", from: "Expense type"
  
  click_button "Save Expense"
  
  assert_text "Expense was successfully created"
  # Normal flow unchanged - backward compatible
end
```

#### Test 3: Session Counter
```ruby
test "session counter shows number of expenses created" do
  visit new_expense_path
  
  # Create first expense
  fill_in "Amount", with: 1000
  select "Personal", from: "Expense type"
  click_button "Create & Add Another"
  assert_text "1 expense created this session"
  
  # Create second expense
  fill_in "Amount", with: 2000
  click_button "Create & Add Another"
  assert_text "2 expenses created this session"
  
  # Create third expense
  fill_in "Amount", with: 3000
  click_button "Create & Add Another"
  assert_text "3 expenses created this session"
end
```

### Bug Fixes

#### 1. Date Parsing Error Handling
**Problem:** Invalid date strings in query params could crash the app  
**Solution:** Added `Date.parse` with `rescue ArgumentError` fallback to `Date.current`

#### 2. Ambiguous Submit Button in Existing Test
**Problem:** `test/system/expenses_test.rb` used generic selector `find('input[type="submit"]').click`, now ambiguous with two buttons  
**Solution:** Changed to `click_button "Save Expense"` (specific button name)

## User Experience Flow

### Scenario: Freelancer logging receipts from a business trip

1. **First expense** - Taxi to airport
   - Amount: ¥3,000
   - Date: 2025-01-15
   - Type: Business
   - Category: Transportation
   - Vendor: Tokyo Taxi
   - Click **"Create & Add Another"** ✅

2. **Second expense** - Flight ticket (common fields pre-filled)
   - ✅ Date: 2025-01-15 (pre-filled)
   - ✅ Type: Business (pre-filled)
   - ✅ Category: Transportation (pre-filled)
   - Amount: ¥25,000 (new)
   - Vendor: ANA Airlines (new)
   - Click **"Create & Add Another"** ✅

3. **Third expense** - Hotel
   - ✅ Date: 2025-01-15 (pre-filled)
   - ✅ Type: Business (pre-filled)
   - Amount: ¥12,000 (new)
   - Category: Accommodation (changed)
   - Vendor: Hotel Nikko (new)
   - Click **"Save Expense"** → Done, redirects to detail page

Counter shows progress: "1 expense created" → "2 expenses created" → Done

## Testing
- ✅ All 36 unit tests passing (68 assertions)
- ✅ All 16 system tests passing (48 assertions)
  - 3 new tests for consecutive entry flow
  - 13 existing tests still passing (backward compatible)
- ✅ RuboCop clean (0 offenses)

## Design Decisions

### Why Pre-fill Type, Date, Category?
- **Type**: Usually batch-entering similar expenses (all business or all personal)
- **Date**: Often entering expenses from same day/trip
- **Category**: Batch scenarios often have category patterns (transportation, meals)

### Why Clear Amount, Vendor, Description?
- **Amount**: Always unique per expense
- **Vendor**: Usually unique (different stores/services)
- **Description**: Specific to each expense

### Why Session Counter?
- Provides positive feedback during batch entry
- Motivates users to continue (gamification)
- Shows progress for large batches

## Acceptance Criteria

- [x] Users can create multiple expenses consecutively
- [x] Common fields pre-filled (expense_type, expense_date, category)
- [x] Unique fields cleared (amount, vendor, description)
- [x] Session counter shows progress
- [x] "Save Expense" button works as before (backward compatible)
- [x] Tests cover consecutive entry flow

## Screenshots
N/A - Feature complete and tested

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)