### PR TITLE
feat: Comprehensive UI/UX polish - consecutive entry toggle + startup-style redesign (#34 #35 #36)

### DIFF
--- a/app/components/expense_card_component.html.erb
+++ b/app/components/expense_card_component.html.erb
@@ -1,33 +1,38 @@
-<div class="bg-white rounded-lg border border-gray-200 p-4 hover:shadow-md transition-shadow duration-200">
+<div class="bg-white rounded-2xl border border-gray-100 p-5 hover:shadow-lg hover:scale-[1.01] transition-all duration-200">
   <div class="flex justify-between items-start mb-3">
     <div class="flex-1">
-      <div class="flex items-center gap-2 mb-1">
-        <span class="text-lg font-semibold text-gray-900"><%= formatted_amount %></span>
+      <div class="flex items-center gap-2 mb-2">
+        <span class="text-xl font-bold text-gray-900"><%= formatted_amount %></span>
         <%= render ExpenseTypeBadgeComponent.new(expense_type: expense.expense_type) %>
       </div>
-      <p class="text-sm text-gray-600"><%= category_display %></p>
+      <p class="text-sm font-medium text-gray-700"><%= category_display %></p>
     </div>
     <div class="text-right">
-      <p class="text-sm text-gray-500"><%= formatted_date %></p>
+      <p class="text-xs text-gray-500"><%= formatted_date %></p>
     </div>
   </div>
-  
-  <div class="flex justify-between items-center text-sm">
+
+  <div class="flex justify-between items-center">
     <div class="flex-1">
-      <p class="text-gray-600 truncate">
+      <p class="text-sm text-gray-600 truncate">
         <% if expense.description.present? %>
           <%= expense.description %>
         <% else %>
-          <span class="text-gray-400">No description</span>
+          <span class="text-gray-400 italic">No description</span>
         <% end %>
       </p>
     </div>
     <div class="ml-4 flex gap-2">
-      <%= link_to expense_path(expense), class: "text-blue-600 hover:text-blue-800 font-medium" do %>
-        View
+      <%= link_to expense_path(expense), class: "inline-flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-900 hover:scale-110 transition-all duration-200", title: "View expense" do %>
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
       <% end %>
-      <%= link_to edit_expense_path(expense), class: "text-gray-600 hover:text-gray-800 font-medium" do %>
-        Edit
+      <%= link_to edit_expense_path(expense), class: "inline-flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 text-gray-600 hover:bg-blue-100 hover:text-blue-700 hover:scale-110 transition-all duration-200", title: "Edit expense" do %>
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
       <% end %>
     </div>
   </div>

--- a/app/components/expense_type_badge_component.html.erb
+++ b/app/components/expense_type_badge_component.html.erb
@@ -1,3 +1,4 @@
 <span class="<%= badge_classes %>">
+  <%= badge_icon %>
   <%= badge_text %>
 </span>

--- a/app/components/expense_type_badge_component.rb
+++ b/app/components/expense_type_badge_component.rb
@@ -10,15 +10,23 @@ class ExpenseTypeBadgeComponent < ViewComponent::Base
   attr_reader :expense_type
 
   def badge_classes
-    base_classes = "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium"
+    "inline-flex items-center gap-1 px-3 py-1 rounded-xl text-xs font-semibold bg-gray-100 text-gray-700 border border-gray-200"
+  end
 
+  def badge_icon
     case expense_type
     when "business"
-      "#{base_classes} bg-green-100 text-green-800"
+      # Briefcase icon
+      '<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>'.html_safe
     when "personal"
-      "#{base_classes} bg-blue-100 text-blue-800"
+      # User icon
+      '<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+      </svg>'.html_safe
     else
-      "#{base_classes} bg-gray-100 text-gray-800"
+      ""
     end
   end
 

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -96,24 +96,47 @@
     </div>
   </div>
 
-  <div class="mt-6 flex justify-between items-center">
+  <!-- Quick Entry Mode Toggle -->
+  <div class="mt-8 pt-6 border-t border-gray-200">
+    <div class="flex items-center mb-4">
+      <input type="checkbox" id="quick-entry-mode" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" <%= 'checked' if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>>
+      <label for="quick-entry-mode" class="ml-3 block">
+        <span class="text-sm font-semibold text-gray-900">Quick Entry Mode</span>
+        <p class="text-xs text-gray-500 mt-0.5">Log multiple expenses without re-entering common fields</p>
+      </label>
+    </div>
+
     <%if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>
-      <div class="text-sm text-green-600 font-medium">
-        ✅ <%= pluralize(flash[:consecutive_count], 'expense') %> created this session
+      <div class="text-sm text-green-600 font-medium mb-4 flex items-center">
+        <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <%= pluralize(flash[:consecutive_count], 'expense') %> created this session
       </div>
-    <% else %>
-      <div></div>
     <% end %>
+  </div>
+
+  <div class="mt-6 flex justify-between items-center">
+    <!-- "Finish & View All" button (only shown in quick entry mode) -->
+    <div id="finish-button-container" class="<%= 'hidden' unless flash[:consecutive_count] && flash[:consecutive_count] > 0 %>">
+      <%= link_to "Finish & View All", expenses_path, class: "px-4 py-2 text-gray-600 hover:text-gray-900 font-medium border-2 border-gray-300 hover:border-gray-400 rounded-xl transition duration-200 inline-block" %>
+    </div>
+    <div class="<%= 'hidden' if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>"></div>
 
     <div class="flex gap-3">
-      <%= form.submit "Save Expense", class: "px-6 py-2 bg-gray-100 text-gray-700 font-medium rounded-xl hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition duration-200" %>
-      <%= form.submit "Create & Add Another", name: "add_another", class: "px-6 py-2 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition duration-200 shadow-md hover:shadow-lg" %>
+      <div id="normal-submit-container" class="<%= 'hidden' if flash[:consecutive_count] && flash[:consecutive_count] > 0 %>">
+        <%= form.submit "Save Expense", class: "px-6 py-2 bg-gray-100 text-gray-700 font-medium rounded-xl hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition duration-200" %>
+      </div>
+      <div id="quick-submit-container" class="<%= 'hidden' unless flash[:consecutive_count] && flash[:consecutive_count] > 0 %>">
+        <%= form.submit "Save & Add Another", name: "add_another", class: "px-6 py-2 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition duration-200 shadow-md hover:shadow-lg" %>
+      </div>
     </div>
   </div>
 <% end %>
 
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+    // Recurring expense checkbox toggle
     const recurringCheckbox = document.querySelector('[name="expense[is_recurring]"]');
     const recurrenceFields = document.getElementById('recurrence-fields');
 
@@ -125,6 +148,37 @@
           recurrenceFields.classList.add('hidden');
         }
       });
+    }
+
+    // Quick Entry Mode toggle
+    const quickEntryCheckbox = document.getElementById('quick-entry-mode');
+    const normalSubmitContainer = document.getElementById('normal-submit-container');
+    const quickSubmitContainer = document.getElementById('quick-submit-container');
+    const finishButtonContainer = document.getElementById('finish-button-container');
+
+    if (quickEntryCheckbox && normalSubmitContainer && quickSubmitContainer) {
+      // Initialize button visibility based on checkbox state
+      function updateButtonVisibility() {
+        if (quickEntryCheckbox.checked) {
+          normalSubmitContainer.classList.add('hidden');
+          quickSubmitContainer.classList.remove('hidden');
+          if (finishButtonContainer) {
+            finishButtonContainer.classList.remove('hidden');
+          }
+        } else {
+          normalSubmitContainer.classList.remove('hidden');
+          quickSubmitContainer.classList.add('hidden');
+          if (finishButtonContainer) {
+            finishButtonContainer.classList.add('hidden');
+          }
+        }
+      }
+
+      // Run on load (after a tiny delay to ensure HTML is fully rendered)
+      setTimeout(updateButtonVisibility, 10);
+
+      // Run on change
+      quickEntryCheckbox.addEventListener('change', updateButtonVisibility);
     }
   });
 </script>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -1,51 +1,92 @@
-<div class="max-w-4xl mx-auto px-4 py-8">
-  <!-- Header -->
-  <div class="flex justify-between items-center mb-8">
-    <div>
-      <h1 class="text-3xl font-bold text-gray-900">Expenses</h1>
-      <p class="text-gray-600 mt-1">Track your personal and business expenses</p>
-    </div>
-    <%= link_to new_expense_path, class: "bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition duration-200 inline-flex items-center gap-2" do %>
-      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
-      </svg>
-      Add Expense
-    <% end %>
-  </div>
-
-  <!-- Summary Cards -->
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-    <div class="bg-white rounded-lg border border-gray-200 p-6">
-      <h3 class="text-sm font-medium text-gray-500">Total Expenses</h3>
-      <p class="text-2xl font-bold text-gray-900 mt-2">¥<%= number_with_delimiter(@expenses.sum(&:amount).to_i) %></p>
-    </div>
-    <div class="bg-green-50 rounded-lg border border-green-200 p-6">
-      <h3 class="text-sm font-medium text-green-700">Business</h3>
-      <p class="text-2xl font-bold text-green-900 mt-2">¥<%= number_with_delimiter(@expenses.business.sum(&:amount).to_i) %></p>
-    </div>
-    <div class="bg-blue-50 rounded-lg border border-blue-200 p-6">
-      <h3 class="text-sm font-medium text-blue-700">Personal</h3>
-      <p class="text-2xl font-bold text-blue-900 mt-2">¥<%= number_with_delimiter(@expenses.personal.sum(&:amount).to_i) %></p>
-    </div>
-  </div>
-
-  <!-- Expense List -->
-  <div class="space-y-4">
-    <% if @expenses.any? %>
-      <% @expenses.order(expense_date: :desc).each do |expense| %>
-        <%= render ExpenseCardComponent.new(expense: expense) %>
-      <% end %>
-    <% else %>
-      <div class="text-center py-12">
-        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
-        </svg>
-        <h3 class="mt-4 text-lg font-medium text-gray-900">No expenses yet</h3>
-        <p class="mt-2 text-gray-500">Get started by adding your first expense.</p>
-        <%= link_to new_expense_path, class: "mt-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700" do %>
-          Add your first expense
+<div class="min-h-screen bg-gradient-to-b from-slate-50 to-white py-12">
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <!-- Header -->
+    <div class="mb-10">
+      <div class="flex justify-between items-end mb-4">
+        <div>
+          <h1 class="text-4xl md:text-5xl font-extrabold text-gray-900 tracking-tight">
+            Dashboard
+          </h1>
+          <p class="text-lg text-gray-600 mt-2">
+            Track your personal and business expenses
+          </p>
+        </div>
+        <%= link_to new_expense_path, class: "bg-blue-600 text-white px-6 py-3 rounded-xl font-semibold hover:bg-blue-700 hover:shadow-lg transition-all duration-200 inline-flex items-center gap-2 shadow-md" do %>
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+          </svg>
+          Add Expense
         <% end %>
       </div>
-    <% end %>
+    </div>
+
+    <!-- Summary Cards -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
+      <div class="bg-white rounded-2xl border border-gray-100 p-6 hover:shadow-lg transition-shadow duration-200">
+        <div class="flex items-center gap-3 mb-2">
+          <div class="w-10 h-10 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-xl flex items-center justify-center">
+            <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+            </svg>
+          </div>
+          <h3 class="text-sm font-semibold text-gray-600">Total Expenses</h3>
+        </div>
+        <p class="text-3xl font-bold text-gray-900">¥<%= number_with_delimiter(@expenses.sum(&:amount).to_i) %></p>
+      </div>
+
+      <div class="bg-white rounded-2xl border border-gray-100 p-6 hover:shadow-lg transition-shadow duration-200">
+        <div class="flex items-center gap-3 mb-2">
+          <div class="w-10 h-10 bg-gradient-to-br from-green-500 to-emerald-500 rounded-xl flex items-center justify-center">
+            <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <h3 class="text-sm font-semibold text-gray-600">Business</h3>
+        </div>
+        <p class="text-3xl font-bold text-gray-900">¥<%= number_with_delimiter(@expenses.business.sum(&:amount).to_i) %></p>
+      </div>
+
+      <div class="bg-white rounded-2xl border border-gray-100 p-6 hover:shadow-lg transition-shadow duration-200">
+        <div class="flex items-center gap-3 mb-2">
+          <div class="w-10 h-10 bg-gradient-to-br from-purple-500 to-fuchsia-500 rounded-xl flex items-center justify-center">
+            <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            </svg>
+          </div>
+          <h3 class="text-sm font-semibold text-gray-600">Personal</h3>
+        </div>
+        <p class="text-3xl font-bold text-gray-900">¥<%= number_with_delimiter(@expenses.personal.sum(&:amount).to_i) %></p>
+      </div>
+    </div>
+
+    <!-- Expense List -->
+    <div>
+      <h2 class="text-2xl font-bold text-gray-900 mb-6">Recent Expenses</h2>
+      <div class="space-y-4">
+        <% if @expenses.any? %>
+          <% @expenses.order(expense_date: :desc).each do |expense| %>
+            <%= render ExpenseCardComponent.new(expense: expense) %>
+          <% end %>
+        <% else %>
+          <div class="text-center py-16 bg-gradient-to-br from-slate-50 to-white rounded-3xl border-2 border-dashed border-gray-200">
+            <div class="w-16 h-16 bg-gray-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <svg class="w-8 h-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+              </svg>
+            </div>
+            <h3 class="text-xl font-bold text-gray-900 mb-2">No expenses yet</h3>
+            <p class="text-gray-500 mb-6 max-w-md mx-auto">
+              Start tracking your expenses and get insights into your spending patterns.
+            </p>
+            <%= link_to new_expense_path, class: "inline-flex items-center px-6 py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 hover:shadow-lg transition-all duration-200 shadow-md" do %>
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+              </svg>
+              Add your first expense
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/test/system/consecutive_entry_toggle_test.rb
+++ b/test/system/consecutive_entry_toggle_test.rb
@@ -1,0 +1,101 @@
+require "application_system_test_case"
+
+class ConsecutiveEntryToggleTest < ApplicationSystemTestCase
+  setup do
+    sign_in users(:one)
+  end
+
+  test "checkbox toggle changes submit button behavior" do
+    visit new_expense_path
+
+    # Initially, Quick Entry Mode checkbox should be unchecked
+    assert_not find_field("Quick Entry Mode").checked?
+
+    # Submit button should say "Save Expense"
+    assert_button "Save Expense"
+
+    # Check the Quick Entry Mode checkbox
+    check "Quick Entry Mode"
+
+    # Submit button should change to "Save & Add Another"
+    assert_button "Save & Add Another"
+
+    # Uncheck the checkbox
+    uncheck "Quick Entry Mode"
+
+    # Submit button should go back to "Save Expense"
+    assert_button "Save Expense"
+  end
+
+  test "with quick entry mode enabled, creates consecutive expenses" do
+    visit new_expense_path
+
+    # Enable Quick Entry Mode
+    check "Quick Entry Mode"
+
+    # Fill in first expense
+    fill_in "Amount", with: 1500
+    fill_in "Expense date", with: "2025-01-15"
+    select "Business", from: "Expense type"
+    fill_in "Category", with: "Food"
+
+    # Submit with Quick Entry Mode enabled
+    click_button "Save & Add Another"
+
+    # Should stay on new expense form
+    assert_current_path new_expense_path
+
+    # Common fields should be pre-filled
+    assert_field "Category", with: "Food"
+
+    # Checkbox should still be checked
+    assert find_field("Quick Entry Mode").checked?
+
+    # Should show success message
+    assert_text "Expense created! Add another or view all expenses."
+  end
+
+  test "with quick entry mode disabled, redirects to expense detail" do
+    visit new_expense_path
+
+    # Leave Quick Entry Mode unchecked (default)
+    assert_not find_field("Quick Entry Mode").checked?
+
+    # Fill in expense
+    fill_in "Amount", with: 1000
+    fill_in "Expense date", with: "2025-01-15"
+    select "Personal", from: "Expense type"
+
+    # Submit normally
+    click_button "Save Expense"
+
+    # Should redirect to show page (not new form)
+    assert_text "Expense was successfully created"
+    assert_no_current_path new_expense_path
+  end
+
+  test "finish link is shown during consecutive entry" do
+    visit new_expense_path
+
+    # Initially, no finish link (Quick Entry Mode unchecked)
+    assert_no_link "Finish & View All"
+
+    # Enable Quick Entry Mode
+    check "Quick Entry Mode"
+
+    # Fill and submit first expense
+    fill_in "Amount", with: 1000
+    fill_in "Expense date", with: "2025-01-15"
+    select "Business", from: "Expense type"
+    click_button "Save & Add Another"
+
+    # Should be on new form with finish link visible
+    assert_current_path new_expense_path
+    assert_link "Finish & View All"
+
+    # Clicking finish link should go to expenses index
+    click_link "Finish & View All"
+    assert_current_path expenses_path
+    assert_text "Dashboard"
+  end
+end

--- a/test/system/consecutive_expense_entry_test.rb
+++ b/test/system/consecutive_expense_entry_test.rb
@@ -8,6 +8,9 @@ class ConsecutiveExpenseEntryTest < ApplicationSystemTestCase
   test "creating expense with 'Create Another' pre-fills common fields" do
     visit new_expense_path
 
+    # Enable Quick Entry Mode
+    check "Quick Entry Mode"
+
     # Fill in first expense
     fill_in "Amount", with: 1500
     fill_in "Expense date", with: "2025-01-15"
@@ -16,8 +19,8 @@ class ConsecutiveExpenseEntryTest < ApplicationSystemTestCase
     fill_in "Vendor", with: "Starbucks"
     fill_in "Description", with: "Coffee meeting"
 
-    # Click "Create & Add Another"
-    click_button "Create & Add Another"
+    # Click "Save & Add Another"
+    click_button "Save & Add Another"
 
     # Should stay on new expense form
     assert_current_path new_expense_path
@@ -43,11 +46,13 @@ class ConsecutiveExpenseEntryTest < ApplicationSystemTestCase
   test "creating expense with 'Done' redirects to index" do
     visit new_expense_path
 
+    # Leave Quick Entry Mode unchecked (default)
+
     fill_in "Amount", with: 1500
     fill_in "Expense date", with: "2025-01-15"
     select "Business", from: "Expense type"
 
-    # Click regular submit button (Done)
+    # Click regular submit button (Save Expense)
     click_button "Save Expense"
 
     # Should redirect to show page (current behavior)
@@ -57,23 +62,26 @@ class ConsecutiveExpenseEntryTest < ApplicationSystemTestCase
   test "session counter shows number of expenses created" do
     visit new_expense_path
 
+    # Enable Quick Entry Mode
+    check "Quick Entry Mode"
+
     # Create first expense
     fill_in "Amount", with: 1000
     fill_in "Expense date", with: "2025-01-15"
     select "Personal", from: "Expense type"
-    click_button "Create & Add Another"
+    click_button "Save & Add Another"
 
     assert_text "1 expense created this session"
 
     # Create second expense
     fill_in "Amount", with: 2000
-    click_button "Create & Add Another"
+    click_button "Save & Add Another"
 
     assert_text "2 expenses created this session"
 
     # Create third expense
     fill_in "Amount", with: 3000
-    click_button "Create & Add Another"
+    click_button "Save & Add Another"
 
     assert_text "3 expenses created this session"
   end

--- a/test/system/expenses_test.rb
+++ b/test/system/expenses_test.rb
@@ -9,7 +9,7 @@ class ExpensesTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit expenses_url
-    assert_selector "h1", text: "Expenses"
+    assert_selector "h1", text: "Dashboard"
   end
 
   test "should create expense" do

--- a/test/system/routing_test.rb
+++ b/test/system/routing_test.rb
@@ -17,7 +17,7 @@ class RoutingTest < ApplicationSystemTestCase
 
     # Should be redirected to expenses page (dashboard)
     assert_current_path expenses_path
-    assert_selector "h1", text: "Expenses"
+    assert_selector "h1", text: "Dashboard"
   end
 
   test "authenticated user accessing /pages/home is also redirected to dashboard" do
@@ -27,6 +27,6 @@ class RoutingTest < ApplicationSystemTestCase
 
     # Should be redirected to expenses page (dashboard)
     assert_current_path expenses_path
-    assert_selector "h1", text: "Expenses"
+    assert_selector "h1", text: "Dashboard"
   end
 end


### PR DESCRIPTION
## Summary
Implements **Issues #34, #35, #36** - Complete UI/UX overhaul with Silicon Valley startup aesthetics

This PR delivers three major improvements in one comprehensive update:
1. **Issue #34**: Consecutive entry toggle/checkbox for better UX
2. **Issue #35**: Expense card and badge redesign with startup-style
3. **Issue #36**: Dashboard page redesign with gradients and polish

All changes follow the startup-style design philosophy documented in CLAUDE.md.

---

## Issue #34: Consecutive Entry Toggle/Checkbox ✅

### Problem
- Two submit buttons caused confusion ("Save Expense" vs "Create & Add Another")
- No clear way to enable/disable consecutive mode
- Users had to click "Back to Dashboard" to stop consecutive logging

### Solution
**Quick Entry Mode checkbox** with dynamic button behavior

### Changes

#### Form (app/views/expenses/_form.html.erb)
- ✅ Add "Quick Entry Mode" checkbox with description
- ✅ Single submit button that changes based on checkbox:
  - **Unchecked (default)**: "Save Expense" → redirects to expense detail
  - **Checked**: "Save & Add Another" → stays on form with pre-filled fields
- ✅ "Finish & View All" link appears during consecutive entry
- ✅ Session counter with checkmark icon
- ✅ JavaScript toggle for smooth button switching
- ✅ Server-side visibility classes for instant render

#### Tests (TDD - 4 new system tests)
```ruby
test "checkbox toggle changes submit button behavior"
test "with quick entry mode enabled, creates consecutive expenses"
test "with quick entry mode disabled, redirects to expense detail"
test "finish link is shown during consecutive entry"
```

### User Flow

**Before:**
1. Click "Create & Add Another" (or "Save Expense"?)
2. No way to stop except navigate away

**After:**
1. Check "Quick Entry Mode" checkbox
2. Click "Save & Add Another" (only visible when checked)
3. Form reloads with type/date/category pre-filled
4. Counter shows: "1 expense created this session"
5. Click "Finish & View All" when done → redirects to dashboard

---

## Issue #35: Expense Cards & Badges Redesign ✅

### Problem
- Green/blue badges (Personal/Business) too colorful
- Text links ("View", "Edit") not startup-style
- Small rounded corners (rounded-lg)
- Boring hover states

### Solution
Subtle gray badges with icons + icon-based action buttons

### Changes

#### Expense Type Badge Component
**File:** `app/components/expense_type_badge_component.rb`

**Before:**
- Green background (bg-green-100) for Business
- Blue background (bg-blue-100) for Personal
- No icons

**After:**
- Subtle gray (bg-gray-100, text-gray-700)
- Icons: 
  - 💼 Briefcase for Business
  - 👤 User for Personal
- Rounded-xl, border, semibold text
- Consistent, minimal design

#### Expense Card Component
**File:** `app/components/expense_card_component.html.erb`

**Card Design:**
- ✅ rounded-2xl (was rounded-lg)
- ✅ border-gray-100 (was border-gray-200)
- ✅ hover:shadow-lg + hover:scale-[1.01]
- ✅ Smooth transitions (duration-200)

**Typography:**
- ✅ Amount: text-xl font-bold (was text-lg semibold)
- ✅ Category: font-medium (was text-sm)

**Action Buttons:**
- ✅ Icon-based instead of text links
- ✅ View: Eye icon in gray-100 circle (w-9 h-9)
- ✅ Edit: Pencil icon in gray-100 circle
- ✅ hover:scale-110 for interactivity
- ✅ Edit button hover:bg-blue-100 hover:text-blue-700

---

## Issue #36: Expenses Index Page Redesign ✅

### Problem
- Small heading (text-3xl)
- Boring summary cards (plain white/green/blue)
- No gradient backgrounds
- Flat, uninspiring design

### Solution
Full startup-style redesign with gradients, large typography, and polish

### Changes

#### Page Layout
**File:** `app/views/expenses/index.html.erb`

**Before:** Plain white background, max-w-4xl  
**After:** Gradient background (slate-50 → white), max-w-6xl

**Header:**
- ✅ "Dashboard" (text-4xl md:text-5xl font-extrabold)
- ✅ Descriptive subheading (text-lg)
- ✅ "Add Expense" button: rounded-xl, shadow-md, hover:shadow-lg

#### Summary Cards

**Before:**
- Total: white bg
- Business: green-50 bg, green text
- Personal: blue-50 bg, blue text

**After:**
- All cards: white bg, gray-100 border, rounded-2xl
- Gradient icon circles (w-10 h-10 rounded-xl):
  - 💳 Total: blue-500 → cyan-500 (wallet icon)
  - 💼 Business: green-500 → emerald-500 (briefcase icon)
  - 👤 Personal: purple-500 → fuchsia-500 (user icon)
- Text-3xl font-bold amounts
- hover:shadow-lg transition

#### Expense List

**Section Heading:** "Recent Expenses" (text-2xl font-bold)

**Empty State:**
- Gradient background (slate-50 → white)
- Rounded-3xl with dashed border-2
- Large icon in gray-100 square (w-16 h-16 rounded-2xl)
- Better copy: "Start tracking your expenses and get insights..."
- Prominent CTA button

---

## Test Updates

Fixed existing tests to match new design:

### Heading Changes
- `test/system/expenses_test.rb` - "Expenses" → "Dashboard"
- `test/system/routing_test.rb` (2 tests) - "Expenses" → "Dashboard"

### Consecutive Entry Changes
- `test/system/consecutive_expense_entry_test.rb` (3 tests):
  - Added `check "Quick Entry Mode"` before form submission
  - Updated button name: "Create & Add Another" → "Save & Add Another"

### New Tests
- `test/system/consecutive_entry_toggle_test.rb` - 4 new tests for toggle behavior

---

## Test Results

✅ **All 36 unit tests passing** (68 assertions)  
✅ **All 20 system tests passing** (64 assertions)  
✅ **RuboCop clean** (0 offenses)

---

## Screenshots
N/A - Visual changes best viewed in browser

---

## Design Philosophy

All changes follow the **Silicon Valley startup aesthetic** documented in CLAUDE.md:

- ✅ Bold typography (text-4xl to text-5xl, extrabold)
- ✅ Generous whitespace (py-12, gap-6)
- ✅ Large rounded corners (rounded-xl, rounded-2xl)
- ✅ Vibrant gradients (blue→cyan, green→emerald, purple→fuchsia)
- ✅ Hover effects (scale, shadow-lg)
- ✅ Subtle color palette (gray-100 backgrounds, not loud colors)

---

## Acceptance Criteria

### Issue #34: ✅
- [x] Clear toggle/checkbox to enable consecutive entry mode
- [x] Single submit button that changes based on mode
- [x] "Finish & View All" button when in consecutive mode
- [x] Session counter still works
- [x] Tests cover toggle behavior

### Issue #35: ✅
- [x] Expense type badges use subtle gray design with icons
- [x] Action buttons are icon-based with hover effects
- [x] Cards use rounded-2xl
- [x] Hover states use scale and shadow-lg
- [x] Design matches startup-style aesthetics
- [x] All functionality works
- [x] Tests pass

### Issue #36: ✅
- [x] Gradient background (slate-50 → white)
- [x] Large, extrabold headings
- [x] Summary cards with subtle design
- [x] Rounded-2xl corners throughout
- [x] Icons for summary cards
- [x] Hover effects on cards
- [x] "Recent Expenses" section heading
- [x] Consistent with startup-style design
- [x] All functionality works
- [x] Tests pass

---

Closes #34  
Closes #35  
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)